### PR TITLE
Add clusty.com based on infospace

### DIFF
--- a/search.yml
+++ b/search.yml
@@ -2063,6 +2063,7 @@ InfoSpace:
     - start.facemoods.com
     - search.magnetic.com
     - search.searchcompletion.com
+    - clusty.com
 
 Interia:
   parameters:


### PR DESCRIPTION
sample url: 
http://www.clusty.com/search?input-form=clusty-simple&v%3Asources=webplus-ns-uf&v%3Aproject=clusty-original&query=Orange+being+dificult+when+unlocking+iPhone+4S+avforums
