### PR TITLE
Maven dependency definition out of date

### DIFF
--- a/java-scala/README.md
+++ b/java-scala/README.md
@@ -56,9 +56,9 @@ Then add into your project's `pom.xml`:
 
 ```xml
 <dependency>
-  <groupId>org.snowplowanalytics</groupId>
-  <artifactId>refererparser</artifactId>
-  <version>0.0.1</version>
+    <groupId>com.snowplowanalytics</groupId>
+    <artifactId>referer-parser</artifactId>
+    <version>0.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The current dependency snippet doesn't work.  Changed the readme to fix it to the format that matches the repo.
