### PR TITLE
Increase performance by 10,000

### DIFF
--- a/ruby/lib/referer-parser/referers.rb
+++ b/ruby/lib/referer-parser/referers.rb
@@ -49,6 +49,7 @@ module RefererParser
     # Initializes a hash of referers
     # from the supplied YAML file
     def self.load_referers_from_yaml(yaml_file)
+      return if @loaded_file == yaml_file
       
       unless File.exist?(yaml_file) and File.file?(yaml_file)
         raise ReferersYamlNotFoundError, "Could not find referers YAML file at '#{yaml_file}'"
@@ -61,6 +62,7 @@ module RefererParser
         raise CorruptReferersYamlError.new("Could not parse referers YAML file '#{yaml_file}'", error)
       end
       @referers = load_referers(yaml)
+      @loaded_file = yaml_file
     end
 
     # Validate and expand the `raw_referers`


### PR DESCRIPTION
`RefererParser` loads it's config file every time it parses an URL, which is totally stupid. This patch fixes it and increases performance by a factor of 10,000 (may vary).
