### PR TITLE
handling invalid referer url

### DIFF
--- a/python/referer_parser/__init__.py
+++ b/python/referer_parser/__init__.py
@@ -40,7 +40,7 @@ class Referer(object):
         self.referers = referers
 
         ref_uri = urlparse(ref_url)
-        ref_host = ref_uri.hostname
+        ref_host = ref_uri.hostname or ''
         self.known = ref_uri.scheme in {'http', 'https'}
         self.uri = ref_uri
 

--- a/python/referer_parser/test/__init__.py
+++ b/python/referer_parser/test/__init__.py
@@ -200,5 +200,9 @@ X&IDMSG=8594&check=&SORTBY=31""")
         self.assertIsNone(r.search_term)
         self.assertIsNone(r.referer)
 
+    def test_invalid_url(self):
+        r = Referer("https:/")
+        self.check_no_term(r, None, 'unknown')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Just ran into this strange referrer url in production ("https:/") and got back an error. Fixed to ignore such cases.
