### PR TITLE
*.subdomain.tld syntax is supported on internal subdomains

### DIFF
--- a/dotnet/RefererParser/Resources/referers.json
+++ b/dotnet/RefererParser/Resources/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/dotnet/RefererParser/Resources/referers.yml
+++ b/dotnet/RefererParser/Resources/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/go/data/referers.json
+++ b/go/data/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/go/data/referers.yml
+++ b/go/data/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/java-scala/src/main/resources/referers.json
+++ b/java-scala/src/main/resources/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/java-scala/src/main/resources/referers.yml
+++ b/java-scala/src/main/resources/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/nodejs/data/referers.json
+++ b/nodejs/data/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/nodejs/data/referers.yml
+++ b/nodejs/data/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/php/data/referers.json
+++ b/php/data/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/php/data/referers.yml
+++ b/php/data/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/php/src/Snowplow/RefererParser/Parser.php
+++ b/php/src/Snowplow/RefererParser/Parser.php
@@ -42,6 +42,17 @@ class Parser
             return Referer::createInternal();
         }
 
+        foreach ($this->internalHosts as $internalHost) {
+                if ('*.' !== substr($internalHost, 0, 2)) {
+                    continue;
+                } 
+
+                $domain_parts = explode('.', $refererParts['host']);
+                if (is_array($domain_parts) && count($domain_parts) >= 2 && implode('.', array_slice($domain_parts, count($domain_parts) - 2, 2)) == substr($internalHost, 2, strlen($internalHost))) {
+                        return Referer::createInternal();
+                }
+        }
+
         $referer = $this->lookup($refererParts['host'], $refererParts['path']);
 
         if (!$referer) {

--- a/php/tests/Snowplow/RefererParser/Tests/AbstractParserTest.php
+++ b/php/tests/Snowplow/RefererParser/Tests/AbstractParserTest.php
@@ -32,7 +32,7 @@ abstract class AbstractParserTest extends TestCase
 
         return $arguments;
     }
-
+    
     /** @dataProvider getTestData */
     public function testRefererParsing($_, $refererUrl, $medium, $source, $searchTerm, $isKnown)
     {
@@ -69,4 +69,11 @@ abstract class AbstractParserTest extends TestCase
         $this->assertSame(Medium::INTERNAL, $parser->parse('http://google.com')->getMedium());
         $this->assertSame(Medium::SEARCH, $this->parser->parse('http://google.com')->getMedium());
     }
+    
+    public function testCustomInternalHostsWithWildCard()
+    {
+        $parser = $this->createParser(['*.facebook.com']);
+        $this->assertSame(Medium::INTERNAL, $parser->parse('http://developers.facebook.com')->getMedium());
+    }
+    
 }

--- a/python/referer_parser/data/referers.json
+++ b/python/referer_parser/data/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/python/referer_parser/data/referers.yml
+++ b/python/referer_parser/data/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #

--- a/ruby/data/referers.json
+++ b/ruby/data/referers.json
@@ -3662,6 +3662,11 @@
                 "mail.qq.com"
             ]
         }, 
+        "Mynet Mail": {
+            "domains": [
+                "mail.mynet.com"
+            ]
+        }, 
         "Gmail": {
             "domains": [
                 "mail.google.com"
@@ -3785,9 +3790,21 @@
                 "vimeo.com"
             ]
         }, 
+        "Eksi Sozluk": {
+            "domains": [
+                "Sozluk.com", 
+                "sourtimes.org"
+            ]
+        }, 
         "Geni": {
             "domains": [
                 "geni.com"
+            ]
+        }, 
+        "Uludag Sozluk": {
+            "domains": [
+                "uludagsozluk.com", 
+                "ulusozluk.com"
             ]
         }, 
         "SourceForge": {
@@ -3832,6 +3849,11 @@
                 "t.co"
             ]
         }, 
+        "Donanimhaber": {
+            "domains": [
+                "donanimhaber.com"
+            ]
+        }, 
         "WAYN": {
             "domains": [
                 "wayn.com"
@@ -3850,6 +3872,11 @@
         "Badoo": {
             "domains": [
                 "badoo.com"
+            ]
+        }, 
+        "Instela": {
+            "domains": [
+                "instela.com"
             ]
         }, 
         "Habbo": {
@@ -3894,8 +3921,9 @@
         }, 
         "Pocket": {
             "domains": [
-                "getpocket.com"
-            ]
+                "itusozluk.com"
+            ], 
+            "ITU Sozluk": null
         }, 
         "Skyrock": {
             "domains": [
@@ -3975,6 +4003,13 @@
                 "stumbleupon.com"
             ]
         }, 
+        "Inci Sozluk": {
+            "domains": [
+                "inci.sozlukspot.com", 
+                "incisozluk.com", 
+                "incisozluk.cc"
+            ]
+        }, 
         "Viadeo": {
             "domains": [
                 "viadeo.com"
@@ -3998,6 +4033,11 @@
         "Hacker News": {
             "domains": [
                 "news.ycombinator.com"
+            ]
+        }, 
+        "Hocam.com": {
+            "domains": [
+                "hocam.com"
             ]
         }, 
         "Delicious": {

--- a/ruby/data/referers.yml
+++ b/ruby/data/referers.yml
@@ -113,6 +113,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
+      
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
 
 # #######################################################################################################
@@ -402,6 +406,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
+      
+    ITU Sozluk:
+    domains:
+      - itusozluk.com
+      
+  Instela:
+    domains:
+      - instela.com
+      
+  Eksi Sozluk:
+    domains:
+      - Sozluk.com
+      - sourtimes.org
+  
+  Uludag Sozluk:
+    domains:
+      - uludagsozluk.com
+      - ulusozluk.com
+  
+  Inci Sozluk:
+    domains:
+      - inci.sozlukspot.com
+      - incisozluk.com
+      - incisozluk.cc
+  
+  Hocam.com:
+    domains:
+      - hocam.com
+      
+  Donanimhaber:
+    domains:
+      - donanimhaber.com    
 
 # #######################################################################################################
 #


### PR DESCRIPTION
I made a small change to support *.example.com

After my update of yesterday, our own platform also appears on social referrer domains but we've more than one subdomains. So, it would be difficult to define every subdomain constructing the parser. Instead of it is possible now to create parser with

```
    $parser = $this->createParser(['*.facebook.com']);
```

Also I cancelled my previous pull request and i'm adding the Turkish providers again. I synced the resources.yml with json file in every platform.
