### PR TITLE
Add Shenma Search and Enterprise QQ Mail

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -180,6 +180,7 @@ email:
   QQ Mail:
     domains:
       - mail.qq.com
+      - exmail.qq.com
 
   Rambler:
     domains:
@@ -3422,6 +3423,18 @@ search:
     domains:
       - sosodesktop.com
       - search.sosodesktop.com
+
+  Shenma:
+    parameters:
+      - q
+    domains:
+      - so.m.sm.cn
+      - yz.m.sm.cn
+      - m.sm.cn
+      - quark.sm.cn
+      - m.sp.sm.cn
+      - m.yz2.sm.cn
+      - m.yz.sm.cn
 
   Snapdo:
     parameters:


### PR DESCRIPTION
This PR adds the Shenma Search and Enterprise QQ Mail domains in the resources/referers.yml, which were found in our running snowplow system and should be recognised. 

I haven't touched any other files yet. But let me know if I should. Thanks!