### PR TITLE
Update referers.yml with Coccoc search engine

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -987,6 +987,12 @@ search:
     domains:
       - pesquisa.clix.pt
 
+  Coccoc:
+    parameters:
+      - q
+    domains:
+      - coccoc.com
+
   Conduit:
     parameters:
       - q


### PR DESCRIPTION
Coccoc is the most used search engine in Vietnam

Changes on this PR:
- Added Coccoc search engine to search section