### PR TITLE
Add Threads detection support

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -276,6 +276,12 @@ social:
       - l.instagram.com
       - com.instagram.android # Instagram for Android app
 
+  Threads:
+    domains:
+      - threads.net
+      - l.threads.net
+      - com.instagram.barcelona # Threads for Android app
+
   Youtube:
     domains:
       - youtube.com


### PR DESCRIPTION
Threads was previously using Instagram's referer URL, but as of December 2023 this has been split out to a dedicated domain.

Source: https://www.socialmediatoday.com/news/threads-adds-separate-link-url-threads-help-track-referral-traffic/702085/

Also add support for the Android app, based on the bundle ID in the Play Store.

E.g. https://play.google.com/store/apps/details?id=com.instagram.barcelona

Thanks: DPG Media