### PR TITLE
Added additional paid Google domains

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -4072,9 +4072,13 @@ paid:
       - www.googleadservices.com
       - partner.googleadservices.com
       - googleads.g.doubleclick.net
+      - tdsf.doubleclick.net
       - tpc.googlesyndication.com
       - googleadservices.com
       - imasdk.googleapis.com
+      - www.adsensecustomsearchads.com
+      - syndicatedsearch.goog
+      - pagead2.googlesyndication.com
 
   LifeStreet:
     domains:


### PR DESCRIPTION
Added the following four Google domains:
- `www.adsensecustomsearchads.com`
- `syndicatedsearch.goog`
- `pagead2.googlesyndication.com`
- `tdsf.doubleclick.net`

The first two are documented here:
https://support.google.com/adsense/answer/14201307

The last two are just ones that I have observed in my access logs.