### PR TITLE
Remove Meta entry

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -3196,12 +3196,6 @@ search:
     domains:
       - maxwebsearch.com
 
-  Meta:
-    parameters:
-      - q
-    domains:
-      - meta.ua
-
   MetaCrawler.de:
     parameters:
       - qry


### PR DESCRIPTION
Now that Facebook has renamed to Meta Platforms, this entry is more likely to cause confusion than anything else.