### PR TITLE
Added Brave search, workplace and lnk.bio (Instagram)

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -275,6 +275,7 @@ social:
       - instagram.com
       - l.instagram.com
       - com.instagram.android # Instagram for Android app
+      - lnk.bio # Instagram bio link tool that allows Instagram users to share multiple links through a single landing page
 
   Threads:
     domains:
@@ -655,6 +656,12 @@ social:
   Whirlpool:
     domains:
       - forums.whirlpool.net.au
+  
+  Workplace:
+    domains:
+      - l.workplace.com
+      - lm.workplace.com
+
 
 # #######################################################################################################
 #
@@ -955,6 +962,12 @@ search:
       - searchTerm
     domains:
       - search.bluewin.ch
+  
+  Brave:
+    parameters:
+      - q
+    domains:
+      - search.brave.com
 
   British Telecommunications:
     parameters:


### PR DESCRIPTION
Based on traffic to tv2.no I say a couple of improvements were needed.
A bit unsure if lnk.bio should be under instragram. As far as I understand it ads one link in peoples Instrame profile page. When click you are sent a landing page with multiple links that the Instragram user can customize. We do get traffic from these landingpages, and for me it makes sense to label it as traffic comming from Instragram. 