### PR TITLE
Rename Meta to Meta.ua

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -3288,7 +3288,7 @@ search:
     domains:
       - maxwebsearch.com
 
-  Meta:
+  Meta.ua:
     parameters:
       - q
     domains:


### PR DESCRIPTION
Based on https://github.com/snowplow-referer-parser/referer-parser/pull/236 , this PR renames `Meta` to `Meta.ua`