### PR TITLE
Fix branch name trigger in tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changed  from 'main' to 'master' as the default branch is 'master'.